### PR TITLE
fix: Crash on application exit.

### DIFF
--- a/qeframeworkSup/project/protocol/QECaClient.cpp
+++ b/qeframeworkSup/project/protocol/QECaClient.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "QECaClient.h"
-#include <QApplication>
 #include <QDebug>
 #include <QMetaType>
 #include <QTimer>
@@ -833,7 +832,9 @@ static QECaClientManager* singleton = NULL;
 void QECaClientManager::initialise ()
 {
    if (!singleton) {   // Mutex needed ??
-      singleton = new QECaClientManager ();
+       // Create a static singleton instance.
+       static QECaClientManager _instance;
+       singleton = &_instance;
    }
 }
 
@@ -854,21 +855,20 @@ QECaClientManager::QECaClientManager () : QObject (NULL)
    ACAI::Client::initialise ();
    ACAI::Client::setNotificationHandler (QECaClientManager::notificationHandlers);
 
-   // Connect to the about to quit signal.
-   // Note: qApp is defined in QApplication
-   //
-   QObject::connect (qApp, SIGNAL (aboutToQuit ()),
-                     this, SLOT   (aboutToQuitHandler ()));
-
    // Schedule first poll event.
    //
    QTimer::singleShot (1, this, SLOT (timeoutHandler ()));
 }
 
 //------------------------------------------------------------------------------
-// destructor - place holder
+// destructor
 //
-QECaClientManager::~QECaClientManager () { }
+QECaClientManager::~QECaClientManager ()
+{
+    // Static variables will be freed when application terminates.
+    // Call `finalise` here.
+    aboutToQuitHandler();
+}
 
 //------------------------------------------------------------------------------
 //


### PR DESCRIPTION
fix issue #11.

The code that caused the error should be here.

https://github.com/qtepics/qeframework/blob/87f56e25d2cab3156de389c31f379997e3afa451/qeframeworkSup/project/protocol/QECaClient.cpp#L897-L901

**QEFramework** called `ACAI::Client::finalise ()` when the program `aboutToQuit`, but at this time the `QCaObject` object has not been deleted yet, and the program exited abnormally when calling the destructor of `QCaObject`.

I tried to create a static `QECaClientManager` singleton that will be automatically destroyed when the application terminates. Now applications can terminate more elegantly.