### PR TITLE
qepicspv: Fixed QEChannel signals names, used appropriate slots.

### DIFF
--- a/qeframeworkSup/project/data/qepicspv.cpp
+++ b/qeframeworkSup/project/data/qepicspv.cpp
@@ -112,10 +112,10 @@ void QEpicsPV::setPV(const QString & _pvName)
   // caused the necessity to register the corresponding types using
   // qRegisterMetaType() functions.
   //
-  connect(_qCaField, SIGNAL(connectionChanged(QCaConnectionInfo&, const unsigned int&)),
+  connect(_qCaField, SIGNAL(connectionUpdated( const QEConnectionUpdate& )),
           SLOT(updateConnection()), Qt::QueuedConnection);
-  connect(_qCaField, SIGNAL(dataChanged(QVariant,QCaAlarmInfo&,QCaDateTime&, const unsigned int&)),
-          SLOT(updateValue(QVariant)), Qt::QueuedConnection);
+  connect(_qCaField, SIGNAL(valueUpdated( const QEVariantUpdate& )),
+          SLOT(updateValue(const QEVariantUpdate&)), Qt::QueuedConnection);
 
   _qCaField->subscribe();
 }
@@ -299,6 +299,10 @@ void QEpicsPV::updateValue(const QVariant & data)
   emit valueUpdated(lastData);
 }
 
+void QEpicsPV::updateValue(const QEVariantUpdate& update)
+{
+  updateValue(update.value);
+}
 
 //------------------------------------------------------------------------------
 //

--- a/qeframeworkSup/project/data/qepicspv.h
+++ b/qeframeworkSup/project/data/qepicspv.h
@@ -31,6 +31,7 @@
 #include <QStringList>
 #include <QEFrameworkLibraryGlobal.h>
 
+#include <QEChannel.h>
 
 class QE_FRAMEWORK_LIBRARY_SHARED_EXPORT QEpicsPV : public QObject {
   Q_OBJECT
@@ -231,6 +232,8 @@ private slots:
   // Used to catch the QEChannel::dataChanged() signal from the ::qCaField.
   // @param data new data.
   void updateValue(const QVariant & data);
+
+  void updateValue(const QEVariantUpdate& update);
 
   // Used to catch QEChannel::connectionChanged() signal from the ::qCaField.
   void updateConnection();


### PR DESCRIPTION
New signals and slots for connection and data changed has not been reflected on QEpicsPV, this resulted in widgets and PV values not updated on the GUI (using code-rich style). Proper `QEChannel` signals have been used and a new `updateValue` overload has been added to connect with `QCaObject::valueUpdated( const QEVariantUpdate& )`.