### PR TITLE
QEWidget.cpp: Set parent and size when loading UI file

### DIFF
--- a/qeframeworkSup/project/widgets/QEWidget/QEWidget.cpp
+++ b/qeframeworkSup/project/widgets/QEWidget/QEWidget.cpp
@@ -847,10 +847,10 @@ void QEWidget::startGui( const QEActionRequests& request )
       // Build the gui
       // Build it in a new window.
       QMainWindow* w = new QMainWindow( this->getQWidget() );
-      QEForm* gui = new QEForm( request.getArguments().first(), this->getQWidget() );
+      QEForm* gui = new QEForm( request.getArguments().first(), w );
       gui->setResizeContents( false );
       if( gui ) {
-         if( gui->readUiFile()) {
+         if( gui->readUiFile() ) {
             w->setCentralWidget( gui );
             w->setAttribute( Qt::WA_DeleteOnClose );
             w->resize( QSize(gui->width(), gui->height()) );

--- a/qeframeworkSup/project/widgets/QEWidget/QEWidget.cpp
+++ b/qeframeworkSup/project/widgets/QEWidget/QEWidget.cpp
@@ -846,11 +846,14 @@ void QEWidget::startGui( const QEActionRequests& request )
    {
       // Build the gui
       // Build it in a new window.
-      QMainWindow* w = new QMainWindow;
-      QEForm* gui = new QEForm( request.getArguments().first() );
+      QMainWindow* w = new QMainWindow( this->getQWidget() );
+      QEForm* gui = new QEForm( request.getArguments().first(), this->getQWidget() );
+      gui->setResizeContents( false );
       if( gui ) {
          if( gui->readUiFile()) {
             w->setCentralWidget( gui );
+            w->setAttribute( Qt::WA_DeleteOnClose );
+            w->resize( QSize(gui->width(), gui->height()) );
             w->show();
          } else {
             delete gui;


### PR DESCRIPTION
We started using guiFile property, we noticed the following issues:

- GUI is loaded but with small dimensions (100x40 or something).
- GUI does not close when parent closes.

I think 1st point is important, the UI file gets loaded but with weird small dimensions. As for the 2nd, I think this can be customized further by adding an option whether to close on exit or not (i.e. setting the parent widget).

I just thought of setting the parent inside the if statement, using w->setParent( this->getQWidget() ); but it rendered the GUI into the button itself, not sure why ...